### PR TITLE
fix featureMask reset

### DIFF
--- a/src/+modelTrainers/Base.m
+++ b/src/+modelTrainers/Base.m
@@ -1,5 +1,6 @@
 classdef (Abstract) Base < handle
-    
+    % Base Abstract ModelTrainers Base class ?
+    %
     %% --------------------------------------------------------------------
     properties (SetAccess = protected)
         trainSet;
@@ -156,8 +157,8 @@ classdef (Abstract) Base < handle
         
         function fm = featureMask( setNewMask, newmask )
             persistent featureMask;
-            if isempty( featureMask )
-                featureMask = [];
+            if ~isempty( featureMask )
+                featureMask = []; % reset the feature mask
             end
             if nargin > 0  &&  setNewMask
                 if ~isempty( newmask ) && size( newmask, 2 ) ~= 1, newmask = newmask'; end;


### PR DESCRIPTION
The `featureMask` of the `modelTrainers.Base` class is set to an empty vector if it already is empty. It seems that the condition needs to be inverted.
