### PR TITLE
add option to read annotations file from absolute path

### DIFF
--- a/src/evaluation/IdEvalFrame.m
+++ b/src/evaluation/IdEvalFrame.m
@@ -110,7 +110,7 @@ classdef IdEvalFrame < handle
         end
         
         function onsetOffsets = readOnOffAnnotations( soundFileName, isAbsPath )
-            if nargin < 1
+            if nargin < 2
                 isAbsPath = false;
             end
             if ~isAbsPath

--- a/src/evaluation/IdEvalFrame.m
+++ b/src/evaluation/IdEvalFrame.m
@@ -109,8 +109,13 @@ classdef IdEvalFrame < handle
             eventClass = soundFileName(classPos1+1:classPos2-1);
         end
         
-        function onsetOffsets = readOnOffAnnotations( soundFileName )
-            soundFileName = getPathPart( soundFileName, 'sound_databases' );
+        function onsetOffsets = readOnOffAnnotations( soundFileName, isAbsPath )
+            if nargin < 1
+                isAbsPath = false;
+            end
+            if ~isAbsPath
+                soundFileName = getPathPart( soundFileName, 'sound_databases' );
+            end
             annotFid = -1;
             try
                 annotFid = fopen( xml.dbGetFile([soundFileName '.txt']) );


### PR DESCRIPTION
This adds an optional argument to treat the argument to IdEvalFrame.readOnOffAnnotations() as an absolute path. Default is set to false.
