### PR TITLE
turn windows style backward slash file separators to forward slashes

### DIFF
--- a/test/buildAndStoreCleanMulticlassData.m
+++ b/test/buildAndStoreCleanMulticlassData.m
@@ -11,7 +11,7 @@ typeMulticlassLabeler = LabelCreators.MultiEventTypeLabeler( ...
 pipe.labelCreator = typeMulticlassLabeler;
 pipe.modelCreator = ModelTrainers.LoadModelNoopTrainer( 'noop' );
 
-pipe.data = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
+pipe.data = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
 pipe.setupData();
 
 sc = SceneConfig.SceneConfiguration();

--- a/test/buildMultioutputData.m
+++ b/test/buildMultioutputData.m
@@ -17,7 +17,7 @@ pipe.labelCreator = multiLabeler;
 pipe.modelCreator = ModelTrainers.LoadModelNoopTrainer( 'noop' );
 pipe.modelCreator.verbose( 'on' );
 
-pipe.trainset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
+pipe.trainset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
 pipe.setupData();
 
 sc(1) = SceneConfig.SceneConfiguration();

--- a/test/buildOnlyCache.m
+++ b/test/buildOnlyCache.m
@@ -9,7 +9,7 @@ babyLabeler = LabelCreators.MultiEventTypeLabeler( 'types', {{'baby'}}, 'negOut'
 pipe.labelCreator = babyLabeler;
 pipe.modelCreator = ModelTrainers.LoadModelNoopTrainer( 'noop' );
 
-pipe.data = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
+pipe.data = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
 pipe.setupData();
 
 sc = SceneConfig.SceneConfiguration();

--- a/test/trainAndTestAlphaSelectGroupedMultiClass.m
+++ b/test/trainAndTestAlphaSelectGroupedMultiClass.m
@@ -22,8 +22,8 @@ pipe.modelCreator = ModelTrainers.GlmNetModelSelectTrainer( ...
  );
 pipe.modelCreator.verbose( 'on' );
 
-pipe.trainset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
-pipe.testset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TestSet_1.flist';
+pipe.trainset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
+pipe.testset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TestSet_1.flist';
 pipe.setupData();
 
 sc = SceneConfig.SceneConfiguration();

--- a/test/trainAndTestAzmOneSrc.m
+++ b/test/trainAndTestAzmOneSrc.m
@@ -15,8 +15,8 @@ pipe.modelCreator = ModelTrainers.GlmNetLambdaSelectTrainer( ...
     'alpha', 0.99 );
 pipe.modelCreator.verbose( 'on' );
 
-pipe.trainset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
-pipe.testset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TestSet_1.flist';
+pipe.trainset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
+pipe.testset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TestSet_1.flist';
 pipe.setupData();
 
 sc = SceneConfig.SceneConfiguration();

--- a/test/trainAndTestNumberSources.m
+++ b/test/trainAndTestNumberSources.m
@@ -53,7 +53,7 @@ pipe.modelCreator = ModelTrainers.LoadModelNoopTrainer( ...
     'performanceMeasure', @PerformanceMeasures.MultinomialBAC );
 pipe.modelCreator.verbose( 'on' );
 
-pipe.testset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TestSet_1.flist';
+pipe.testset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TestSet_1.flist';
 pipe.setupData();
 
 sc(1) = SceneConfig.SceneConfiguration();

--- a/test/trainAndTestOverlappedMultiClass.m
+++ b/test/trainAndTestOverlappedMultiClass.m
@@ -22,7 +22,7 @@ pipe.modelCreator = ModelTrainers.GlmNetLambdaSelectTrainer( ...
     'alpha', 0.99 );
 pipe.modelCreator.verbose( 'on' );
 
-pipe.trainset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
+pipe.trainset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
 pipe.setupData();
 
 sc = SceneConfig.SceneConfiguration();
@@ -59,7 +59,7 @@ pipe.modelCreator = ModelTrainers.LoadModelNoopTrainer( ...
     'performanceMeasure', @PerformanceMeasures.MultinomialBAC );
 pipe.modelCreator.verbose( 'on' );
 
-pipe.testset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TestSet_1.flist';
+pipe.testset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TestSet_1.flist';
 pipe.setupData();
 
 sc = SceneConfig.SceneConfiguration();

--- a/test/trainAndTestSegmented.m
+++ b/test/trainAndTestSegmented.m
@@ -15,7 +15,7 @@ pipe.modelCreator = ModelTrainers.GlmNetLambdaSelectTrainer( ...
     'alpha', 0.99 );
 pipe.modelCreator.verbose( 'on' );
 
-pipe.trainset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
+pipe.trainset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TrainSet_1.flist';
 pipe.setupData();
 
 sc = SceneConfig.SceneConfiguration();
@@ -45,7 +45,7 @@ pipe.modelCreator = ModelTrainers.LoadModelNoopTrainer( ...
     'performanceMeasure', @PerformanceMeasures.BAC );
 pipe.modelCreator.verbose( 'on' );
 
-pipe.trainset = 'learned_models\IdentityKS\trainTestSets/NIGENS160807_mini_TestSet_1.flist';
+pipe.trainset = 'learned_models/IdentityKS/trainTestSets/NIGENS160807_mini_TestSet_1.flist';
 pipe.setupData();
 
 sc = SceneConfig.SceneConfiguration();


### PR DESCRIPTION
Matlab should still be able to resolve paths with fwd slashes on windows.
