### PR TITLE
multilabeler: concatenate non-scalar labels

### DIFF
--- a/src/+LabelCreators/MultiLabeler.m
+++ b/src/+LabelCreators/MultiLabeler.m
@@ -24,9 +24,10 @@ classdef MultiLabeler < LabelCreators.Base
     methods (Access = protected)
         
         function y = label( obj, blockAnnotations )
+            y = [];
             for ii = 1 : numel( obj.individualLabelers )
                 obj.individualLabelers{ii}.labelBlockSize_s = obj.labelBlockSize_s;
-                y(1,ii) = obj.individualLabelers{ii}.label( blockAnnotations );
+                y = [y, obj.individualLabelers{ii}.label( blockAnnotations )];
             end
         end
         %% -------------------------------------------------------------------------------


### PR DESCRIPTION
Concatenation of labels produced by individual labelers in `LabelCreators.MultiLabeler` only works for scalar labels.
This extends it to enable concatenation of scalar as well as labels shaped as row vectors.
