### PR TITLE
live eval fixes and updates

### DIFF
--- a/src/evaluation/liveRec/Config.xml
+++ b/src/evaluation/liveRec/Config.xml
@@ -3,6 +3,6 @@
     <TwoEarsPart sub="src" startup="startBinauralSimulator">binaural-simulator</TwoEarsPart>
     <TwoEarsPart startup="startAuditoryFrontEnd">auditory-front-end</TwoEarsPart>
     <TwoEarsPart startup="startBlackboardSystem">blackboard-system</TwoEarsPart>
-    <TwoEarsPart startup="startIdentificationTraining">identification-training</TwoEarsPart>
+    <TwoEarsPart startup="startAMLTTP">identification-training</TwoEarsPart>
     <TwoEarsPart sub="API_MO" startup="SOFAstart">sofa</TwoEarsPart>
 </requirements>

--- a/src/evaluation/liveRec/readMixtureOnOffSets.m
+++ b/src/evaluation/liveRec/readMixtureOnOffSets.m
@@ -11,4 +11,7 @@ if numel( target_names ) > 1
 else
     mixture_onOffSets{1} = IdEvalFrame.readOnOffAnnotations(fpath_mixture, true);
 end
+% remove '-' from grouped classes to match model naming convention
+target_names = cellfun(@(x) strrep(x, '-', ''), ...
+        target_names, 'un', false);
 end

--- a/src/evaluation/liveRec/script_eval_rec.m
+++ b/src/evaluation/liveRec/script_eval_rec.m
@@ -8,12 +8,12 @@
 % [idModels(1:6).dir] = deal( '../../../../twoears-database-internal/learned_models/IdentityKS/mc1_models_dataset_1' );
 
 %% mc1b_models_dataset_1
-idModels(1).name = 'alarm';
-idModels(2).name = 'baby';
-idModels(5).name = 'fire';
-idModels(4).name = 'femaleSpeech';
-idModels(3).name = 'dog';
-[idModels(1:5).dir] = deal( '../../../../twoears-database-internal/learned_models/IdentityKS/mc1b_models_dataset_1' );
+% idModels(1).name = 'alarm';
+% idModels(2).name = 'baby';
+% idModels(5).name = 'fire';
+% idModels(4).name = 'femaleSpeech';
+% idModels(3).name = 'dog';
+% [idModels(1:5).dir] = deal( '../../../../twoears-database-internal/learned_models/IdentityKS/mc1b_models_dataset_1' );
 
 %% mc2_models_dataset_1
 % idModels(1).name = 'alarm';
@@ -36,9 +36,56 @@ idModels(3).name = 'dog';
 % idModels(3).name = 'femaleSpeech';
 % [idModels(1:4).dir] = deal( '../../../../twoears-database-internal/learned_models/IdentityKS/mc2segmented_models_dataset_1' );
 
+%% mc3_fc3_models_dataset_1
+idModels(1).name = 'alarm';
+idModels(2).name = 'baby';
+idModels(3).name = 'crash';
+idModels(4).name = 'dog';
+idModels(5).name = 'engine';
+idModels(6).name = 'femaleScreammaleScream';
+idModels(7).name = 'femaleSpeech';
+idModels(8).name = 'fire';
+idModels(9).name = 'footsteps';
+idModels(10).name = 'knock';
+idModels(11).name = 'maleSpeech';
+idModels(12).name = 'phone';
+idModels(13).name = 'piano';
+[idModels(1:13).dir] = deal( '../../../../twoears-database-internal/learned_models/IdentityKS/mc3_fc3_models_dataset_1' );
+
+%% mc3_fc4_0.5s_models_dataset_1
+% idModels(1).name = 'alarm';
+% idModels(2).name = 'baby';
+% idModels(3).name = 'crash';
+% idModels(4).name = 'dog';
+% idModels(5).name = 'engine';
+% idModels(6).name = 'femaleScreammaleScream';
+% idModels(7).name = 'femaleSpeech';
+% idModels(8).name = 'fire';
+% idModels(9).name = 'footsteps';
+% idModels(10).name = 'knock';
+% idModels(11).name = 'maleSpeech';
+% idModels(12).name = 'phone';
+% idModels(13).name = 'piano';
+% [idModels(1:13).dir] = deal( '../../../../twoears-database-internal/learned_models/IdentityKS/mc3_fc4_0.5s_models_dataset_1' );
+
+%% mc3_fc4_1s_models_dataset_1
+% idModels(1).name = 'alarm';
+% idModels(2).name = 'baby';
+% idModels(3).name = 'crash';
+% idModels(4).name = 'dog';
+% idModels(5).name = 'engine';
+% idModels(6).name = 'femaleScreammaleScream';
+% idModels(7).name = 'femaleSpeech';
+% idModels(8).name = 'fire';
+% idModels(9).name = 'footsteps';
+% idModels(10).name = 'knock';
+% idModels(11).name = 'maleSpeech';
+% idModels(12).name = 'phone';
+% idModels(13).name = 'piano';
+% [idModels(1:13).dir] = deal( '../../../../twoears-database-internal/learned_models/IdentityKS/mc3_fc4_1s_models_dataset_1' );
 %%
-ppRemoveDc = true;
-fs = 44100;
+ppRemoveDc = false;
+fs = 16000;
 
 data_dir = '../../../../twoears-database-internal';
 flist = ...
@@ -92,7 +139,7 @@ flist = ...
     fullfile(data_dir, 'sound_databases/adream_1609/rec/bagfiles_20160929_E/mat/femaleSpeech.mat'), ...
     fullfile(data_dir, 'sound_databases/adream_1609/rec/bagfiles_20160929_E/mat/maleSpeech.mat'), ...
     fullfile(data_dir, 'sound_databases/adream_1609/rec/bagfiles_20160929_E/mat/maleSpeech_femaleSpeech.mat'), ...
-    }; 
+    };
 % onset of first chirp (inclusive) to offset of final chirp
 % (inclusive) in samples
 session_onOffSet = [1.236e+05, 8582556;...   % alarm

--- a/src/evaluation/liveRec/splitTargetNames.m
+++ b/src/evaluation/liveRec/splitTargetNames.m
@@ -1,7 +1,5 @@
 function [target_names] = splitTargetNames(fpath)
 
 [~, fname, ~] = fileparts( fpath );
-c = strsplit( fname, '-' );
-target_names = strsplit( c{1}, '_' );
-
+target_names = strsplit( fname, '_' );
 end


### PR DESCRIPTION
Fix to handle grouped classes (e.g. scream classes) and match models to the annotation files of the recordings (e.g. femaleScreammaleScream vs femaleScream-maleScream)

adds mc3 models to the evaluation script

updates dc removal flag to false and sets AFE's sampling rate parameter to 16000 Hz
