### PR TITLE
use output LocalisationDecisionKS instead raw DnnLocationKS

### DIFF
--- a/src/+DataProcs/DnnLocKsWrapper.m
+++ b/src/+DataProcs/DnnLocKsWrapper.m
@@ -60,9 +60,11 @@ classdef DnnLocKsWrapper < DataProcs.BlackboardKsWrapper
         
         function afeData = addLocData( afeData, locData )
             locFakeAFEsignal = struct();
-            locFakeAFEsignal.Data = locData.sourcesDistribution(:)';
+%             locFakeAFEsignal.Data = locData.sourcesDistribution(:)';
+            locFakeAFEsignal.Data = locData.sourcesPosteriors(:)';
             locFakeAFEsignal.Name = 'DnnLocationDistribution';
-            locFakeAFEsignal.azms = locData.azimuths(:)';
+%             locFakeAFEsignal.azms = locData.azimuths(:)';
+            locFakeAFEsignal.azms = locData.sourceAzimuths(:)';
             afeData(afeData.Count+1) = locFakeAFEsignal;
         end
         %% -------------------------------------------------------------------------------


### PR DESCRIPTION
For now, this only fixes the static method.
It would break training new models. Before merging, need to resolve integrating any other KSs used by `LocalisationDecisionKS` into `DnnLocKsWrapper`