### PR TITLE
Brir binsim update fix

### DIFF
--- a/src/+DataProcs/IdSimConvRoomWrapper.m
+++ b/src/+DataProcs/IdSimConvRoomWrapper.m
@@ -214,7 +214,7 @@ classdef IdSimConvRoomWrapper < Core.IdProcInterface
                 [~,~,brirTorsoDefault] = obj.convRoomSim.Sources{1}.getHeadLimits();
                 obj.convRoomSim.moveRobot( crp(1), crp(2), brirTorsoDefault, 'absolute' );
                 % 'absolute' mode means: relative wrt torso...
-                headToTorsoAzm = mod( headOrientation(1), 360 ) - brirTorsoDefault;
+                headToTorsoAzm = mod( headOrientation(1), 360 ) - mod( brirTorsoDefault, 360 );
                 obj.convRoomSim.rotateHead( headToTorsoAzm, 'absolute' );
                 
                 % set processing sample rate

--- a/src/+DataProcs/IdSimConvRoomWrapper.m
+++ b/src/+DataProcs/IdSimConvRoomWrapper.m
@@ -180,7 +180,7 @@ classdef IdSimConvRoomWrapper < Core.IdProcInterface
                 obj.convRoomSim.Sources{1}.Azimuth = obj.srcAzimuth;
             elseif isa( sceneConfig.sources(1), 'SceneConfig.BRIRsource' ) 
                 obj.convRoomSim.Sources{1} = simulator.source.Point();
-                
+
                 if isempty( obj.IRDataset ) ...
                    || ~strcmp( obj.IRDataset.fname, sceneConfig.sources(1).brirFName ) ...
                    || (isfield( obj.IRDataset, 'speakerId' ) ~= ~isempty( sceneConfig.sources(1).speakerId ) ) ...
@@ -202,15 +202,21 @@ classdef IdSimConvRoomWrapper < Core.IdProcInterface
                     obj.IRDataset.fname = sceneConfig.sources(1).brirFName;
                 end
                 obj.convRoomSim.Sources{1}.IRDataset = obj.IRDataset.dir;
+
+                % load SOFA meta + some IR data (to get the sample rate)
+                brirSofa = SOFAload( ...
+                             db.getFile( sceneConfig.sources(1).brirFName ), [1 2], 'N' );
+                
+                headOrientation = SceneConfig.BRIRsource.getBrirHeadOrientation( ...
+                                                brirSofa, sceneConfig.brirHeadOrientIdx );
                 obj.srcAzimuth = sceneConfig.sources(1).azimuth;
                 [crp(1),crp(2)] = obj.convRoomSim.getCurrentRobotPosition();
                 [~,~,brirTorsoDefault] = obj.convRoomSim.Sources{1}.getHeadLimits();
                 obj.convRoomSim.moveRobot( crp(1), crp(2), brirTorsoDefault, 'absolute' );
-                obj.convRoomSim.rotateHead( -obj.srcAzimuth, 'absolute' );
+                % 'absolute' mode means: relative wrt torso...
+                headToTorsoAzm = mod( headOrientation(1), 360 ) - brirTorsoDefault;
+                obj.convRoomSim.rotateHead( headToTorsoAzm, 'absolute' );
                 
-                % load SOFA meta + some IR data to get the sample rate
-                brirSofa = SOFAload( ...
-                             db.getFile( sceneConfig.sources(1).brirFName ), [1 2], 'N' );
                 % set processing sample rate
                 set( obj.convRoomSim, 'SampleRate', brirSofa.Data.SamplingRate );
             

--- a/src/+SceneConfig/BRIRsource.m
+++ b/src/+SceneConfig/BRIRsource.m
@@ -36,16 +36,20 @@ classdef BRIRsource < SceneConfig.SourceBase & Parameterized
 
         function calcAzimuth( obj, brirHeadOrientIdx )
             brirSofa = SOFAload( db.getFile( obj.brirFName ), 'nodata' );
-            headOrientIdx = ceil( brirHeadOrientIdx * size( brirSofa.ListenerView, 1 ));
-            headOrientation = SOFAconvertCoordinates( ...
-                brirSofa.ListenerView(headOrientIdx,:),'cartesian','spherical' );
+            headOrientIdx = ceil( 1 + brirHeadOrientIdx * (size( brirSofa.ListenerView, 1 ) - 1));
+            if (strcmpi(brirSofa.ListenerView_Type, 'cartesian'))
+                headOrientation = SOFAconvertCoordinates( ...
+                    brirSofa.ListenerView(headOrientIdx,:),'cartesian','spherical' );
+            else
+                headOrientation = brirSofa.ListenerView(headOrientIdx,1);
+            end
             if isempty( obj.speakerId )
                 sid = 1;
             else
                 sid = obj.speakerId;
             end
             brirSrcPos = SOFAconvertCoordinates( ...
-                        brirSofa.EmitterPosition(sid,:) - brirSofa.ListenerPosition, ...
+                        brirSofa.SourcePosition(sid,:) - brirSofa.ListenerPosition, ...
                                                                 'cartesian','spherical' );
             obj.azimuth = brirSrcPos(1) - headOrientation(1);
         end


### PR DESCRIPTION
1) Updated pipeline BinSim wrapper to reflect newly included torso azimuth. 
2) Included auto-recognition of whether sourcePos or emitterPos is used in sofa meta data.

Tested to produce correct earsignals with ADREAM and qu_kemar_rooms BRIR files. Please test on further files.